### PR TITLE
Add Contribution Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,4 @@ To utilize logging within a local development environment, please review the com
 - [Implementation Guide](docs/implementation-guide.md)
 - [Internal Format Guide](docs/internal-format.md)
 - [IDE Configuration](docs/ide.md)
+- [Contributing](docs/contributing.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,52 @@
+## Contributing In General
+Our project gladly welcomes external contributions!  We use [Pull Requests](https://github.com/LinuxForHealth/csvtofhir/pulls).
+
+A good way to familiarize yourself with the codebase and contribution process is to review the [documentation](../README.md).
+You can also look at our [issue tracker](https://github.com/LinuxForHealth/csvtofhir/issues).
+Before embarking on a more ambitious contribution, please [get in touch](#communication) with us.
+
+### Proposing new features
+
+If you would like to implement a new feature, please [raise an issue](https://github.com/LinuxForHealth/csvtofhir/issues)
+before sending a pull request so the feature can be discussed. This is to avoid
+you wasting your valuable time working on a feature that the project developers
+are not interested in accepting into the code base.
+
+### Fixing bugs 
+
+If you would like to fix a bug, please [raise an issue](https://github.com/LinuxForHealth/csvtofhir/issues) before sending a
+pull request, so it can be tracked.
+
+### Merge approval
+
+A pull request requires approval from at least one of the [maintainers](../CODEOWNERS).
+
+## Legal
+
+We have tried to make it as easy as possible to make contributions. This
+applies to how we handle the legal aspects of contribution. We use the [Developer's Certificate of Origin 1.1 (DCO)](https://github.com/hyperledger/fabric/blob/master/docs/source/DCO1.1.txt) - which is the same that the Linux® Kernel [community](https://elinux.org/Developer_Certificate_Of_Origin)
+uses to manage code contributions.
+
+When submitting a patch for review, we require that you include a sign-off statement in the commit message.
+
+Here is an example Signed-off-by line, which indicates that the
+submitter accepts the DCO:
+
+```
+Signed-off-by: Jane Doe <jane.doe@example.com>
+```
+
+You can include this automatically when you commit a change to your
+local git repository using the following command:
+
+```
+git commit -s
+```
+
+## Communication
+To connect with us, please open an [issue](https://github.com/LinuxForHealth/csvtofhir/issues) or contact one of the maintainers via email. 
+See the [MAINTAINERS.md](../CODEOWNERS) page.
+
+## Testing
+To ensure a working build, please run the full build from the root of the project before submitting your pull request.
+Pull Requests should include necessary updates to unit tests within the [tests package](../tests).


### PR DESCRIPTION
This PR adds contribution documentation, similar to what we're using in the HL7 to FHIR Converter.

One notable exception is that I removed the guidance on applying the software license reference to each source file. We will discuss this requirement internally and create a PR to address, if necessary.

closes #7 

Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>