### PR TITLE
Publish Releases to PyPI

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,7 +5,7 @@ on:
     types: [ published ]
 
 jobs:
-  publish-release:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: name: Publish Release to PyPi
+name: Publish Release to PyPi
 
 on:
   release:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,7 +2,7 @@ name: Publish Release to PyPi
 
 on:
   release:
-    types: [ published ]
+    types: [published]
 
 jobs:
   publish:
@@ -29,4 +29,5 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.PYPI_PUBLISH_TOKEN }}
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,11 +2,10 @@ name: Publish Release to PyPi
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
   publish-release:
-    name: Publish CsvToFhir Releases to PyPI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,33 @@
+name: Publish Release to PyPi
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-release:
+    name: Publish CsvToFhir Releases to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,32 +1,34 @@
-name: Publish Release to PyPi
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: name: Publish Release to PyPi
 
 on:
   release:
     types: [published]
 
 jobs:
-  publish:
+  deploy:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@master
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.10"
-    - name: Install pypa/build
-      run: >-
-        python -m
-        pip install
-        build
-        --user
-    - name: Build a binary wheel and a source tarball
-      run: >-
-        python -m
-        build
-        --sdist
-        --wheel
-        --outdir dist/
-    - name: Publish distribution 📦 to PyPI
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__


### PR DESCRIPTION
This PR adds support for publishing "published" CsvToFHIR releases to PyPI.
We will test this action once we are ready for the next release.

closes #9 

Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>