### PR TITLE
Issue13 make conditionDiagnosisUse multivalued

### DIFF
--- a/docs/internal-format.md
+++ b/docs/internal-format.md
@@ -70,9 +70,8 @@ The Condition Dictionary Record contains the following fields:
 - conditionClinicalStatus
 - conditionVerificationStatus
 - conditionDiagnosisRank
-- conditionPrincipalDiagnosis
-- conditionRoleIsAdmitting
-- conditionRoleIsChiefComplaint
+- conditionDiagnosisUse
+
 - conditionRecordedDateTime
 - conditionOnsetDateTime
 - conditionAbatementDateTime

--- a/src/linuxforhealth/csvtofhir/fhirrs/condition.py
+++ b/src/linuxforhealth/csvtofhir/fhirrs/condition.py
@@ -164,19 +164,11 @@ def _connect_encoding_references(
                 diagnosis_id = code_cc.text
         enc.diagnosis = []
         rank = incoming_data.get_encounter_diagnosis_rank_int()
-        # Build Encounter.diagnosis elements, one entry per diagnosis.use
-        if incoming_data.conditionRoleIsAdmitting and \
-                incoming_data.conditionRoleIsAdmitting.lower() in csv_utils.TRUE_STRINGS:
-            diagnosis = _build_diagnosis_with_use("AD", rank, diagnosis_id, condition_reference)
+        # Build Encounter.diagnosis element for diagnosis.use
+        if incoming_data.conditionDiagnosisUse:
+            diagnosis = _build_diagnosis_with_use(incoming_data.conditionDiagnosisUse, rank, diagnosis_id, condition_reference)
             enc.diagnosis.append(diagnosis)
-        if incoming_data.conditionRoleIsChiefComplaint and \
-                incoming_data.conditionRoleIsChiefComplaint.lower() in csv_utils.TRUE_STRINGS:
-            diagnosis = _build_diagnosis_with_use("CC", rank, diagnosis_id, condition_reference)
-            enc.diagnosis.append(diagnosis)
-        if incoming_data.conditionPrincipalDiagnosis and \
-                incoming_data.conditionPrincipalDiagnosis.lower() in csv_utils.TRUE_STRINGS:
-            diagnosis = _build_diagnosis_with_use("principal-diagnosis", rank, diagnosis_id, condition_reference)
-            enc.diagnosis.append(diagnosis)
+
         if not len(enc.diagnosis):  # no dianosis.use values, add single diagnosis element without 'use'
             diagnosis = EncounterDiagnosis.construct(
                 id=diagnosis_id,
@@ -204,10 +196,7 @@ def _build_diagnosis_with_use(use_code: str, rank: int, id: str, condition_refer
         condition=condition_reference
     )
     # Set diagnosis.id
-    if rank:  # rank is first choice
-        diagnosis.id = id
-    else:     # role hyphen Condition.code is second choice
-        diagnosis.id = use_code + "-" + id
+    diagnosis.id = id
     return diagnosis
 
 

--- a/src/linuxforhealth/csvtofhir/fhirutils/fhir_constants.py
+++ b/src/linuxforhealth/csvtofhir/fhirutils/fhir_constants.py
@@ -186,8 +186,12 @@ class EncounterResource:
     }
     diagnosis_use_display = {  # http://terminology.hl7.org/CodeSystem/diagnosis-role plus more from CDM
         "AD": "Admission diagnosis",
+        "DD": "Discharge diagnosis",
         "CC": "Chief complaint",
-        "principal-diagnosis": "Principal diagnosis"
+        "CM": "Comorbidity diagnosis",
+        "pre-op": "pre-op diagnosis",
+        "post-op": "post-op diagnosis",
+        "billing": "Billing"
     }
 
 

--- a/src/linuxforhealth/csvtofhir/model/csv/condition.py
+++ b/src/linuxforhealth/csvtofhir/model/csv/condition.py
@@ -41,10 +41,8 @@ class ConditionCsv(CsvBaseModel):
 
     # only used when category=diagnosis-condition; not used for problem-list-item
     conditionDiagnosisRank: Optional[str]
-    # use / role(s) of the diagnosis in the encounter
-    conditionPrincipalDiagnosis: Optional[str]
-    conditionRoleIsAdmitting: Optional[str]
-    conditionRoleIsChiefComplaint: Optional[str]
+    # use of the diagnosis in the encounter
+    conditionDiagnosisUse: Optional[str]
 
     conditionCode: Optional[str]
     conditionCodeSystem: Optional[str] = DEFAULT_CONDITION_CODE_SYSTEM
@@ -77,8 +75,7 @@ class ConditionCsv(CsvBaseModel):
         # is no other Encounter data.  Note that if there is no encounterInternalId we do not create an Encounter
         # in this case, since not having an Encounter.id would result in an
         # 'orphaned' skeleton Encounter that is not useful.
-        if self.encounterInternalId or self.encounterClaimType or self.conditionRoleIsAdmitting or \
-           self.conditionRoleIsChiefComplaint or self.conditionDiagnosisRank:
+        if self.encounterInternalId or self.encounterClaimType or self.conditionDiagnosisUse or self.conditionDiagnosisRank:
             return True
         return False
 

--- a/src/linuxforhealth/csvtofhir/pipeline/tasks.py
+++ b/src/linuxforhealth/csvtofhir/pipeline/tasks.py
@@ -628,7 +628,8 @@ def replace_text(
     :param data_frame: The input DataFrame
     :param column_name: The DataFrame column name.
     :param match: The string to match. Or pattern if REGEX option.
-    :param replacement: The string to replace it with.  Or pattern if REGEX option.
+    :param replacement: The string to replace it with, or pattern if REGEX option. Replacement must be a string. 
+        If need is to empty the cell, match on entire contents and replace with ''.
     :param options: optional string of options, defaults to None, which is match anywhere, case sensitive
         BEGIN = match at the beginning of the string. Can be combined with CASE_INSENSITIVE and/or END.
         END = match at the end of the word. Can be combined with CASE_INSENSITIVE and/or BEGIN.

--- a/tests/fhirrs/test_condition.py
+++ b/tests/fhirrs/test_condition.py
@@ -1147,7 +1147,7 @@ def test_convert_condition_encounter_diagnosis2(
     assert diff == "", diff
 
 
-# similar to test_convert_condition_encounter_diagnosis3, except conditionDiagnosisUse has no
+# similar to test_convert_condition_encounter_diagnosis2, except conditionDiagnosisUse has no
 # conditionDiagnosisRank
 def test_convert_condition_encounter_diagnosis3(
     condition_record_encounter_diagnosis3,


### PR DESCRIPTION
Signed-off-by: Brian Cragun <bcragun@merative.com>

Addresses #13 

- change Condition/model from three effectively boolean values ( conditionPrincipalDiagnosis conditionRoleIsAdmitting &
conditionRoleIsChiefComplaint) to a single conditionDiagnosisUse, which has possible values: AD, DD, CC, CM, pre-op, post-op, and billing. (See https://terminology.hl7.org/3.1.0/CodeSystem-diagnosis-role.html)
- Add display names for these values in fhir_constants.EncounterResource
- Create processing in Condition/ffhirs based on the conditionDiagnosisUse
-  Remove decoration of use code + Id. Use the straight ID

Updates and adds unit tests and documentation.