### PR TITLE
Add info logging before and after conversion

### DIFF
--- a/src/linuxforhealth/csvtofhir/converter.py
+++ b/src/linuxforhealth/csvtofhir/converter.py
@@ -136,20 +136,20 @@ def convert(file_path: str) -> Generator[Tuple[Any, str, List[str]], None, None]
         try:
             processing_exception: Optional[Exception] = None
             result: List[str] = []
-            logger.info((f"Converting row {row.rowNum} groupByKey={row.groupByKey} file_path={row.filePath} ") \
-                      + (f"resourceType={row.configResourceType}"))
+            logger.debug((f"Converting groupByKey={row.groupByKey} resourceType={row.configResourceType}"))
+            logger.info((f"Converting row {row.rowNum} file_path={row.filePath} "))
             result = convert_to_fhir(
                 row.groupByKey,
                 row.to_dict(),
                 _append_row_num_to_file_meta(
                     resource_meta,
                     row.rowNum))
-            logger.info(f"Finished Converting row {row.rowNum} groupByKey={row.groupByKey} file_path={row.filePath} " \
-                        + (f"resourceType={row.configResourceType}.  The following resourceTypes were created: ") \
+            logger.info(f"Finished converting row {row.rowNum} file_path={row.filePath} " \
+                        + ("  The following resourceTypes were created: ") \
                         + ', '.join(support.get_fhir_resource_types(result)))
         except Exception as ex:
             logger.error(f"Convert failed with {ex.__class__.__name__} Error on converting row {row.rowNum} " \
-                         + (f"groupByKey={row.groupByKey} file_path={row.filePath} resourceType={row.configResourceType}"))
+                         + (f"file_path={row.filePath}"))
             processing_exception = ex
 
         return processing_exception, row.groupByKey, result

--- a/src/linuxforhealth/csvtofhir/converter.py
+++ b/src/linuxforhealth/csvtofhir/converter.py
@@ -136,17 +136,20 @@ def convert(file_path: str) -> Generator[Tuple[Any, str, List[str]], None, None]
         try:
             processing_exception: Optional[Exception] = None
             result: List[str] = []
-            log_message = (f"Converting row {row.rowNum} groupByKey={row.groupByKey} file_path={row.filePath} " +
-                           "resourceType={row.configResourceType}")
-            logger.debug(log_message)
+            logger.info((f"Converting row {row.rowNum} groupByKey={row.groupByKey} file_path={row.filePath} ") \
+                      + (f"resourceType={row.configResourceType}"))
             result = convert_to_fhir(
                 row.groupByKey,
                 row.to_dict(),
                 _append_row_num_to_file_meta(
                     resource_meta,
                     row.rowNum))
+            logger.info(f"Finished Converting row {row.rowNum} groupByKey={row.groupByKey} file_path={row.filePath} " \
+                        + (f"resourceType={row.configResourceType}.  The following resourceTypes were created: ") \
+                        + ', '.join(support.get_fhir_resource_types(result)))
         except Exception as ex:
-            logger.error(f"Convert failed with {ex.__class__.__name__} Error")
+            logger.error(f"Convert failed with {ex.__class__.__name__} Error on converting row {row.rowNum} " \
+                         + (f"groupByKey={row.groupByKey} file_path={row.filePath} resourceType={row.configResourceType}"))
             processing_exception = ex
 
         return processing_exception, row.groupByKey, result

--- a/src/linuxforhealth/csvtofhir/support.py
+++ b/src/linuxforhealth/csvtofhir/support.py
@@ -22,6 +22,20 @@ def find_fhir_resources(resources: List, resource_type: str) -> List[Dict]:
     return matches
 
 
+def get_fhir_resource_types(resources: List) -> List[str]:
+    """
+    Returns resource types from a list
+    :param resources: List of resources
+    :return: List of resource types
+    """
+    retVal = []
+    for result in resources:
+        resource = json.loads(result)
+        retVal.append(resource.get("resourceType", ""))
+
+    return retVal
+
+
 def read_csv(filepath: str) -> Dict:
     """
     Reads a csv file and converts to Dict
@@ -49,6 +63,7 @@ def get_logger(name):
     """
     logger = logging.getLogger(name)
     logger.addHandler(NullHandler())
+    logger.setLevel(logging.INFO)
 
     # uncomment the lines below to enable local environment logging
 

--- a/src/linuxforhealth/csvtofhir/support.py
+++ b/src/linuxforhealth/csvtofhir/support.py
@@ -69,7 +69,7 @@ def get_logger(name):
 
     # from logging import StreamHandler
     # logger.setLevel(logging.DEBUG)
-    # stream_handler = StreamHandler()
+    # stream_handler = logging.StreamHandler()
     # stream_handler.setLevel(logging.DEBUG)
     #
     # formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
In this PR, the following updates have been made:
- updated the loggers to log info level messages (the default was warning and error)
- fixed messages that spanned multiple lines
- Changed before-conversion message from debug to info level
- Added info level message after conversion which includes the row number, group-by key, input file name, the resource type from the input file, and the resource types of the resulting FHIR resources.
- Fixed error message so that 2nd line of message will include the desired values