### PR TITLE
Refactoring smart_open usage as an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ To execute unit tests, simply run:
 python -m pytest
 ```
 
+### Optimized Streaming Support
+Csv To FHIR provides an optimized means of streaming files using [smart_open](https://pypi.org/project/smart-open/). smart_open
+supports streaming files from common cloud storage stores (AWS, Azure, GCS) as well as over common transfer protocols such
+as HTTP, HTTPS, SFTP, HDFS, etc.
+
+To include smart_open, install the optimized-streaming extra
+
+```shell
+python -m pip install -e ".[optimized-streaming]"
+```
+
 ### CSVToFHIR CLI
 The CLI supports:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ install_requires =
     python-dotenv >=0.20, <1.0
     python-dateutil >=2.8, <3.0
     pytz ==2022.1
-    smart_open >=6.2.0
 package_dir =
     = src
 python_requires = >=3.9
@@ -44,6 +43,7 @@ console_scripts =
 [options.extras_require]
 dev = pytest >=7.1, <8.0;flake8 >=4.0, <5.0;autopep8 >=1.6, <2.0;isort >= 5.10, <6.0
 notebook = jupyterlab
+optimized-streaming = smart_open >=6.2.0
 
 
 [flake8]

--- a/src/linuxforhealth/csvtofhir/cli/convert.py
+++ b/src/linuxforhealth/csvtofhir/cli/convert.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 
 from linuxforhealth.csvtofhir.converter import convert
 from linuxforhealth.csvtofhir.model.contract import DataContract, load_data_contract
-from linuxforhealth.csvtofhir.support import validate_paths
+from linuxforhealth.csvtofhir.support import validate_paths, open_file
 
 
 def _filter_input_files(input_files: List[str], config_dir: str) -> List[str]:
@@ -204,7 +204,7 @@ def _write_fhir_resources(
         fixture_file_name = f"{group_key}-{resource_type}-{source_file_id}-{resource_count_display}.json"
         fixture_path = os.path.join(group_key_dir, fixture_file_name)
 
-        with open(fixture_path, "w") as w:
+        with open_file(fixture_path, "w") as w:
             w.write(json.dumps(r, indent=4, sort_keys=True))
 
 

--- a/src/linuxforhealth/csvtofhir/converter.py
+++ b/src/linuxforhealth/csvtofhir/converter.py
@@ -6,7 +6,7 @@ import pandas as pd
 from fhir.resources.meta import Meta
 from numpy import integer
 from pandas import DataFrame, Series
-from smart_open import parse_uri
+from linuxforhealth.csvtofhir.support import parse_uri_scheme
 
 from linuxforhealth.csvtofhir.model.contract import FileType
 
@@ -38,7 +38,7 @@ def validate_contract() -> DataContract:
     """
     config = get_converter_config()
 
-    if parse_uri(config.configuration_path).scheme == 'file' and not os.path.exists(config.configuration_path):
+    if parse_uri_scheme(config.configuration_path) == 'file' and not os.path.exists(config.configuration_path):
         msg = f"Unable to load Data Contract configuration from {config.configuration_path}"
         logger.error(msg)
         raise FileNotFoundError(msg)
@@ -204,7 +204,6 @@ def _convert(file_path: str, create_fhir_resources: bool) -> Generator[Tuple[Any
     file_name = os.path.basename(file_path)
     file_definition_lookup = os.path.splitext(file_name)[0]
     file_definition: Optional[FileDefinition] = None
-
 
     for k, v in contract.fileDefinitions.items():
         if contract.general.regexFilenames:

--- a/src/linuxforhealth/csvtofhir/model/contract.py
+++ b/src/linuxforhealth/csvtofhir/model/contract.py
@@ -9,9 +9,7 @@ from fhir.resources.fhirtypesvalidators import MODEL_CLASSES
 
 from linuxforhealth.csvtofhir.config import get_converter_config
 from linuxforhealth.csvtofhir.model.base import ImmutableModel
-from linuxforhealth.csvtofhir.support import get_logger
-
-from smart_open import open, parse_uri
+from linuxforhealth.csvtofhir.support import get_logger, parse_uri_scheme, open_file
 
 logger = get_logger(__name__)
 
@@ -216,7 +214,6 @@ class FileDefinition(ImmutableModel):
         return values
 
 
-
 class DataContract(ImmutableModel):
     """
     Specifies how CSV records are mapped to FHIR resources.
@@ -233,13 +230,13 @@ class DataContract(ImmutableModel):
         try:
             for key, value in values.items():
                 if isinstance(value, str):
-                    if parse_uri(value).scheme == 'file' and not path.isabs(value):
+                    if parse_uri_scheme(value) == 'file' and not path.isabs(value):
                         file_directory = path.dirname(get_converter_config().configuration_path)
                         filepath = path.join(file_directory, value)
                     else:
                         filepath = value
 
-                    with open(filepath) as fd:
+                    with open_file(filepath) as fd:
                         file_definition = FileDefinition(**json.load(fd))
                         values[key] = file_definition
             return values
@@ -254,5 +251,5 @@ def load_data_contract(file_path: str) -> DataContract:
     :param file_path: The path to the resource mapping configuration
     :return: dictionary
     """
-    with open(file_path, "rt") as r:
+    with open_file(file_path, "rt") as r:
         return DataContract(**json.load(r))

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -5,9 +5,9 @@ from typing import Dict, List
 import pytest
 
 from linuxforhealth.csvtofhir.support import (find_fhir_resources, is_valid_year, read_csv,
+
                                               validate_paths, parse_uri_scheme)
-import sys
-from unittest import mock
+
 
 @pytest.fixture
 def practitioner() -> str:

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -261,7 +261,7 @@ def test_validate_paths(data_contract_directory: str):
     [
         ("/opt/data/data.csv", "file"),
         ("C:/data/data.csv", "file"),
-        ("http://somserver/file.dat", "http")
+        ("http://someserver/file.dat", "http")
     ]
 )
 def test_parse_uri_scheme(input_uri, expected_uri):

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -5,8 +5,9 @@ from typing import Dict, List
 import pytest
 
 from linuxforhealth.csvtofhir.support import (find_fhir_resources, is_valid_year, read_csv,
-                                              validate_paths)
-
+                                              validate_paths, parse_uri_scheme)
+import sys
+from unittest import mock
 
 @pytest.fixture
 def practitioner() -> str:
@@ -253,3 +254,16 @@ def test_validate_paths(data_contract_directory: str):
 
     with pytest.raises(FileNotFoundError):
         validate_paths(paths, raise_exception=True)
+
+
+@pytest.mark.parametrize(
+    "input_uri, expected_uri",
+    [
+        ("/opt/data/data.csv", "file"),
+        ("C:/data/data.csv", "file"),
+        ("http://somserver/file.dat", "http")
+    ]
+)
+def test_parse_uri_scheme(input_uri, expected_uri):
+    actual_scheme = parse_uri_scheme(input_uri)
+    assert expected_uri == actual_scheme


### PR DESCRIPTION
This PR updates Csv To FHIR project to treat "smart_open" as an optional dependency with the following changes:

- define a new "optimized-streaming" extra in setup.cfg
- add new functions in support.py to support parsing a uri scheme and opening a file
- within the new support.py functions deferred imports are used

Note that the GitHub Actions test jobs DO NOT load the smart_open dependency at this time.

One caveat with this approach is that we can't use mocks or fixtures within the tests to simulate when smart_open is included or excluded since deferred imports are used. However one could argue that this would require more of an "integration" test to fully ensure that data contracts are read from external systems correctly.

closes #50 

Signed-off-by: Dixon Whitmire <dixonwh@gmail.com>